### PR TITLE
updating custom `toBase64()` methods with `btoa()` standardized JS method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Many podcast apps have deterministic URLs if you know their Apple ID or feed URL
 * Bullhorn: `https://bullhorn.fm/podchaser/itunes/${appleID}`
 * Castbox: `https://castbox.fm/vic/${appleID}`
 * Castro: `https://castro.fm/itunes/${appleID}`
-* Google Podcasts: `https://podcasts.google.com/?feed=${toBase64(feedUrl)}`
+* Google Podcasts: `https://podcasts.google.com/?feed=${btoa(feedUrl)}`
 * Listen Notes: `https://listennotes.com/itunes/id${appleID}`
 * Overcast: `https://overcast.fm/itunes${appleID}`
 * Player FM: `https://player.fm/series/${encodeURIComponent(feedUrl)}`
@@ -43,7 +43,7 @@ Many podcast apps have deterministic URLs if you know their Apple ID or feed URL
 ## Episodes
 
 ### Deterministic Episode Links
-* Google Podcasts: `https://podcasts.google.com/?feed=${toBase64(feedUrl)}&episode=${toBase64(episodeGuid)}`
+* Google Podcasts: `https://podcasts.google.com/?feed=${btoa(feedUrl)}&episode=${btoa(episodeGuid)}`
 * Player FM: `https://player.fm/series/${encodeURIComponent(feedUrl)}/guid:${encodeURIComponent(episodeGuid)}`
 * Podcast Addict: `https://podcastaddict.com/episode/${encodeURIComponent(audioFileUrl)}`
 

--- a/README.md
+++ b/README.md
@@ -76,3 +76,6 @@ For the purposes of this list, a `slug` is a string with an arbitrary value. Itâ
 * Request Apple episode IDs from an `appleID`: `GET https://itunes.apple.com/lookup?id=${appleID}&entity=podcastEpisode&limit=300`
 * Request a Breaker ID from an `appleID`/`feedUrl`: [Documentation](https://blog.breaker.audio/how-to-add-a-podcast-to-breaker-68677e12c0c3#4d0f)
 * Request a Podcast Index ID from an `appleID`/`feedUrl`: [Documentation](https://podcastindex-org.github.io/docs-api/#podcasts)
+
+## Technical Considerations
+* Instead of btoa(), Google Podcasts uses a URL-safe variant of base64 for their hashes that replaces `+` and `/` with `-` and `_` respectively.


### PR DESCRIPTION
PR suggests changes to use a [standardized base64 encoding method](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa) (`btoa()`) throughout documentation, versus custom `toBase64()` that was in-place.