### PR TITLE
Update README.md - podStation subscribe pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | TrueFans            | ❌            | `https://truefans.fm/${uniquePlatformID}`                                                                                                     |
 | Podfriend           | ✅            | `https://web.podfriend.com/podcast/${appleID}`                                                                                                |
 | Podknife            | ✅            | `https://podknife.com/podcast?feed_url=${feedURL}`                                                                                            |
-| podStation          | ✅            | `https://podstation.github.io/subscribe-ext/?feedURL=${appleID}`                                                                              |
+| podStation          | ✅            | `https://podstation.github.io/subscribe-ext/?feedURL=${feedURL}`                                                                              |
 | Podverse            | ✅            | `https://api.podverse.fm/api/v1/podcast/podcastindex/${podcastIndexShowID}`                                                                   |
 | Podvine             | ✅            | `https://podvine.com/link?feed=${feedURL}`                                                                                                    |
 | RadioPublic         | ✅            | `https://radiopublic.com/${encodeURIComponent(feedUrl)}`                                                                                      |


### PR DESCRIPTION
Fixed the podStation URL pattern for subscribing to a show.

Reference:
- https://github.com/podStation/podstation.github.io/blob/07f930d957ee569967c6cbd321a3ea2f8635f815/docs/javascripts/subscribeInPodstation.js