### PR TITLE
Add Apollo; remove Google Podcasts & Radio Public

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | Fountain            | ✅            | `https://fountain.fm/show/${podcastIndexShowID}`                                                                                              |
 | Global Player       | ❌            | `https://www.globalplayer.com/podcasts/${uniquePlatformID}`                                                                                   |
 | Goodpods            | ✅            | `https://www.goodpods.com/podcasts-aid/${appleID}`                                                                                            |
-| Google Podcasts[^1] | ✅            | `https://podcasts.google.com/?feed=${base64url(feedURL)}` <br> `https://podcasts.google.com/subscribe-by-rss-feed?feed=${base64url(feedURL)}` |
 | gPodder             | ✅            | `https://gpodder.net/subscribe?url=${feedURL}`                                                                                                |
 | Hark                | ❌            | `https://harkaudio.com/p/${uniquePlatformID}`                                                                                                 |
 | iHeartRadio         | ❌            | `https://iheart.com/podcast/${uniquePlatformID}`                                                                                              |
@@ -65,7 +64,6 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | Podknife            | ✅            | `https://podknife.com/podcast?feed_url=${feedURL}`                                                                                            |
 | podStation          | ✅            | `https://podstation.github.io/subscribe-ext/?feedURL=${feedURL}`                                                                              |
 | Podverse            | ✅            | `https://api.podverse.fm/api/v1/podcast/podcastindex/${podcastIndexShowID}`                                                                   |
-| RadioPublic[^2]     | ✅            | `https://radiopublic.com/${encodeURIComponent(feedUrl)}`                                                                                      |
 | Snipd               | ❌            | `https://share.snipd.com/show/${uniquePlatformID}`                                                                                            |
 | Sonnet              | ✅            | `https://sonnet.fm/p/${appleID}`                                                                                                              |
 | Spotify             | ❌            | `https://open.spotify.com/${uniquePlatformID}`                                                                                                |
@@ -88,7 +86,6 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | Fountain            | ✅            | `https://fountain.fm/episode/${podcastIndexEpisodeID}`                                                     |
 | Global Player       | ❌            | `https://www.globalplayer.com/podcasts/episodes/${uniqueEpisodeID}/`                                       |
 | Goodpods            | ❌            | `https://goodpods.com/podcasts/${uniquePlatformID}/${uniqueEpisodeID}`                                     |
-| Google Podcasts[^1] | ✅            | `https://podcasts.google.com/?feed=${base64url(feedURL)}&episode=${base64url(episodeGUID)}`                |
 | Hark                | ❌            | `https://harkaudio.com/p/${uniquePlatformID}/${uniqueEpisodeID}`                                           |
 | iHeartRadio         | ❌            | `https://iheart.com/podcast/${slug}-${uniquePlatformID}/episode/${slug}-${uniqueEpisodeID}`                |
 | Jam                 | ❌            | `https://www.listentojam.com/jam/${uniquePlatformID}/${uniqueEpisodeID}`                                   |
@@ -104,7 +101,6 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | Podfriend           | ✅            | `https://podfriend.com/podcast/${appleID}/${encodeURIComponent(episodeGUID)}`                              |
 | Podknife            | ❌            | `https://podknife.com/episodes/${uniqueEpisodeID}`                                                         |
 | Podverse            | ❌            | `https://podverse.fm/episode/${uniqueEpisodeID}`                                                           |
-| RadioPublic[^2]     | ✅            | `https://radiopublic.com/${encodeURIComponent(feedUrl)}/${uniqueEpisodeID}`                                |
 | Snipd               | ❌            | `https://share.snipd.com/episode/${uniquePlatformID}`                                                      |
 | Sonnet              | ❌            | `https://sonnet.fm/p/${appleID}/${uniqueEpisodeID}`                                                        |
 | Spotify             | ❌            | `https://open.spotify.com/episode/${uniqueEpisodeID}`                                                      |
@@ -135,7 +131,6 @@ These resources also support podcast foreign keys, but their primary purpose may
 ## API Documentation
 * [Apple Podcasts](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/)
 * [Deezer](https://developers.deezer.com/api/podcast)
-* [Google Podcasts](https://podnews.net/article/google-podcasts-app-faq#-how-can-i-programmatically-check-that-a-feed-is-in-google-podcasts)
 * [Listen Notes](https://www.listennotes.com/api/docs/)
 * [Pocket Casts](https://pocketcasts.com/submit/)
 * [Podcast Index](https://podcastindex-org.github.io/docs-api/#podcasts)
@@ -147,5 +142,3 @@ If you have an update to improve this guide, please [fork the repo](https://gith
 
 ## Footnotes
 [^1]: For fiction podcasts only
-[^1]: [Google Podcasts to shut down in 2024 with listeners migrated to YouTube Music](https://techcrunch.com/2023/09/26/google-podcasts-to-shut-down-in-2024-with-listeners-migrated-to-youtube-music/)
-[^2]: [RadioPublic is to close on March 31, 2024](https://podnews.net/uploads/radiopublic-closure.png)

--- a/README.md
+++ b/README.md
@@ -29,85 +29,85 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 * `uniquePlatformID` and `uniqueEpisodeID`: A platform-specific identifier that may only be obtained via API or not at all.
 
 ## Show Links
-| Platform            | Foreign Keys | URL Pattern                                                                                                                                   |
-|---------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| Amazon Music        | ❌            | `https://music.amazon.com/podcasts/${uniquePlatformID}`                                                                                       |
-| AntennaPod          | ✅            | `https://antennapod.org/deeplink/subscribe?url=${feedURL}`                                                                                    |
-| Anytime Player      | ✅            | `https://anytimeplayer.app/subscribe?url=${feedURL}`                                                                                          |
-| Apollo[^1]          | ✅            | `https://shows.apollopods.com/show?feedUrl=${feedURL}`                                                                                        |
-| Apple Podcasts      | ✅            | `https://podcasts.apple.com/podcast/id${appleID}`                                                                                             |
-| Breez               | ✅            | `https://breez.link/p?feedURL=${encodeURIComponent(feedURL)}`                                                                                 |
-| Castamatic          | ✅            | `https://castamatic.com/guid/${podcastGUID}`                                                                                                  |
-| Castbox             | ✅            | `https://castbox.fm/vic/${appleID}`                                                                                                           |
-| Castro              | ✅            | `https://castro.fm/itunes/${appleID}`                                                                                                         |
-| CurioCaster         | ✅            | `https://curiocaster.com/podcast/pi${podcastIndexShowID}`                                                                                     |
-| Deezer              | ❌            | `https://www.deezer.com/show/${uniquePlatformID}`                                                                                             |
-| Fountain            | ✅            | `https://fountain.fm/show/${podcastIndexShowID}`                                                                                              |
-| Global Player       | ❌            | `https://www.globalplayer.com/podcasts/${uniquePlatformID}`                                                                                   |
-| Goodpods            | ✅            | `https://www.goodpods.com/podcasts-aid/${appleID}`                                                                                            |
-| gPodder             | ✅            | `https://gpodder.net/subscribe?url=${feedURL}`                                                                                                |
-| Hark                | ❌            | `https://harkaudio.com/p/${uniquePlatformID}`                                                                                                 |
-| iHeartRadio         | ❌            | `https://iheart.com/podcast/${uniquePlatformID}`                                                                                              |
-| Jam                 | ✅            | `https://www.listentojam.com/itunes/${appleID}`                                                                                               |
-| Luminary            | ❌            | `https://luminarypodcasts.com/listen/${slug}/${slug}/${uniquePlatformID}`                                                                     |
-| Moon FM             | ✅            | `https://moon.fm/itunes/${appleID}`                                                                                                           |
-| Overcast            | ✅            | `https://overcast.fm/itunes${appleID}`                                                                                                        |
-| Pandora             | ❌            | `https://pandora.com/podcast/${slug}/PC:${uniquePlatformID}`                                                                                  |
-| Player FM           | ✅            | `https://player.fm/subscribe?id=${encodeURIComponent(feedURL)}`                                                                               |
-| Pocket Casts        | ✅            | `https://pca.st/itunes/${appleID}` <br> `https://pcasts.in/feed/${feedURL}`                                                                   |
-| Podbean             | ✅            | `https://www.podbean.com/itunes/${appleID}`                                                                                                   |
-| Podcast Addict      | ✅            | `https://podcastaddict.com/feed/${encodeURIComponent(feedURL)}`                                                                               |
-| Podcast App         | ❌            | `https://podcast.app/${slug}-p${uniquePlatformID}`                                                                                            |
-| Podcast Guru        | ✅            | `https://app.podcastguru.io/podcast/${appleID}`                                                                                               |
-| Podcast Republic    | ✅            | `https://www.podcastrepublic.net/podcast/${appleID}`                                                                                          |
-| Podfriend           | ✅            | `https://podfriend.com/podcast/${appleID}`                                                                                                    |
-| Podknife            | ✅            | `https://podknife.com/podcast?feed_url=${feedURL}`                                                                                            |
-| podStation          | ✅            | `https://podstation.github.io/subscribe-ext/?feedURL=${feedURL}`                                                                              |
-| Podverse            | ✅            | `https://api.podverse.fm/api/v1/podcast/podcastindex/${podcastIndexShowID}`                                                                   |
-| Snipd               | ❌            | `https://share.snipd.com/show/${uniquePlatformID}`                                                                                            |
-| Sonnet              | ✅            | `https://sonnet.fm/p/${appleID}`                                                                                                              |
-| Spotify             | ❌            | `https://open.spotify.com/${uniquePlatformID}`                                                                                                |
-| Steno.fm            | ✅            | `https://steno.fm/show/${podcastGUID}`                                                                                                        |
-| TrueFans            | ✅            | `https://truefans.fm/${podcastGUID}`                                                                                                          |
-| TuneIn              | ❌            | `https://tunein.com/podcasts/${uniquePlatformID}`                                                                                             |
-| YouTube Music       | ❌            | `https://music.youtube.com/playlist?list=${uniquePlatformID}`                                                                                 |
+| Platform         | Foreign Keys | URL Pattern                                                                 |
+|------------------|--------------|-----------------------------------------------------------------------------|
+| Amazon Music     | ❌            | `https://music.amazon.com/podcasts/${uniquePlatformID}`                     |
+| AntennaPod       | ✅            | `https://antennapod.org/deeplink/subscribe?url=${feedURL}`                  |
+| Anytime Player   | ✅            | `https://anytimeplayer.app/subscribe?url=${feedURL}`                        |
+| Apollo[^1]       | ✅            | `https://shows.apollopods.com/show?feedUrl=${feedURL}`                      |
+| Apple Podcasts   | ✅            | `https://podcasts.apple.com/podcast/id${appleID}`                           |
+| Breez            | ✅            | `https://breez.link/p?feedURL=${encodeURIComponent(feedURL)}`               |
+| Castamatic       | ✅            | `https://castamatic.com/guid/${podcastGUID}`                                |
+| Castbox          | ✅            | `https://castbox.fm/vic/${appleID}`                                         |
+| Castro           | ✅            | `https://castro.fm/itunes/${appleID}`                                       |
+| CurioCaster      | ✅            | `https://curiocaster.com/podcast/pi${podcastIndexShowID}`                   |
+| Deezer           | ❌            | `https://www.deezer.com/show/${uniquePlatformID}`                           |
+| Fountain         | ✅            | `https://fountain.fm/show/${podcastIndexShowID}`                            |
+| Global Player    | ❌            | `https://www.globalplayer.com/podcasts/${uniquePlatformID}`                 |
+| Goodpods         | ✅            | `https://www.goodpods.com/podcasts-aid/${appleID}`                          |
+| gPodder          | ✅            | `https://gpodder.net/subscribe?url=${feedURL}`                              |
+| Hark             | ❌            | `https://harkaudio.com/p/${uniquePlatformID}`                               |
+| iHeartRadio      | ❌            | `https://iheart.com/podcast/${uniquePlatformID}`                            |
+| Jam              | ✅            | `https://www.listentojam.com/itunes/${appleID}`                             |
+| Luminary         | ❌            | `https://luminarypodcasts.com/listen/${slug}/${slug}/${uniquePlatformID}`   |
+| Moon FM          | ✅            | `https://moon.fm/itunes/${appleID}`                                         |
+| Overcast         | ✅            | `https://overcast.fm/itunes${appleID}`                                      |
+| Pandora          | ❌            | `https://pandora.com/podcast/${slug}/PC:${uniquePlatformID}`                |
+| Player FM        | ✅            | `https://player.fm/subscribe?id=${encodeURIComponent(feedURL)}`             |
+| Pocket Casts     | ✅            | `https://pca.st/itunes/${appleID}` <br> `https://pcasts.in/feed/${feedURL}` |
+| Podbean          | ✅            | `https://www.podbean.com/itunes/${appleID}`                                 |
+| Podcast Addict   | ✅            | `https://podcastaddict.com/feed/${encodeURIComponent(feedURL)}`             |
+| Podcast App      | ❌            | `https://podcast.app/${slug}-p${uniquePlatformID}`                          |
+| Podcast Guru     | ✅            | `https://app.podcastguru.io/podcast/${appleID}`                             |
+| Podcast Republic | ✅            | `https://www.podcastrepublic.net/podcast/${appleID}`                        |
+| Podfriend        | ✅            | `https://podfriend.com/podcast/${appleID}`                                  |
+| Podknife         | ✅            | `https://podknife.com/podcast?feed_url=${feedURL}`                          |
+| podStation       | ✅            | `https://podstation.github.io/subscribe-ext/?feedURL=${feedURL}`            |
+| Podverse         | ✅            | `https://api.podverse.fm/api/v1/podcast/podcastindex/${podcastIndexShowID}` |
+| Snipd            | ❌            | `https://share.snipd.com/show/${uniquePlatformID}`                          |
+| Sonnet           | ✅            | `https://sonnet.fm/p/${appleID}`                                            |
+| Spotify          | ❌            | `https://open.spotify.com/${uniquePlatformID}`                              |
+| Steno.fm         | ✅            | `https://steno.fm/show/${podcastGUID}`                                      |
+| TrueFans         | ✅            | `https://truefans.fm/${podcastGUID}`                                        |
+| TuneIn           | ❌            | `https://tunein.com/podcasts/${uniquePlatformID}`                           |
+| YouTube Music    | ❌            | `https://music.youtube.com/playlist?list=${uniquePlatformID}`               |
 
 ## Episode Links
-| Platform            | Foreign Keys | URL Pattern                                                                                                |
-|---------------------|--------------|------------------------------------------------------------------------------------------------------------|
-| Amazon Music        | ❌            | `https://music.amazon.com/podcasts/${uniquePlatformID}/episodes/${uniqueEpisodeID}`                        |
-| Apple Podcasts      | ❌            | `https://podcasts.apple.com/podcast/id${appleID}?i=${uniqueEpisodeID}`                                     |
-| Breez               | ✅            | `https://breez.link/p?feedURL=${encodeURIComponent(feedURL)}&episodeID=${encodeURIComponent(episodeGUID)}` |
-| Bullhorn            | ❌            | `https://bullhorn.fm/${uniquePlatformID}/posts/${uniqueEpisodeID}`                                         |
-| Castamatic          | ❌            | `https://castamatic.com/+${uniqueEpisodeID}`                                                               |
-| Castbox             | ❌            | `https://castbox.fm/episode/${slug}-id${uniquePlatformID}-id${uniqueEpisodeID}`                            |
-| Castro              | ❌            | `https://castro.fm/episode/${uniqueEpisodeID}`                                                             |
-| Deezer              | ❌            | `https://www.deezer.com/episode/${uniqueEpisodeID}`                                                        |
-| Fountain            | ✅            | `https://fountain.fm/episode/${podcastIndexEpisodeID}`                                                     |
-| Global Player       | ❌            | `https://www.globalplayer.com/podcasts/episodes/${uniqueEpisodeID}/`                                       |
-| Goodpods            | ❌            | `https://goodpods.com/podcasts/${uniquePlatformID}/${uniqueEpisodeID}`                                     |
-| Hark                | ❌            | `https://harkaudio.com/p/${uniquePlatformID}/${uniqueEpisodeID}`                                           |
-| iHeartRadio         | ❌            | `https://iheart.com/podcast/${slug}-${uniquePlatformID}/episode/${slug}-${uniqueEpisodeID}`                |
-| Jam                 | ❌            | `https://www.listentojam.com/jam/${uniquePlatformID}/${uniqueEpisodeID}`                                   |
-| Luminary            | ❌            | `https://luminarypodcasts.com/listen/${slug}/${uniquePlatformID}/${slug}/${uniqueEpisodeID}`               |
-| Overcast            | ❌            | `https://overcast.fm/+${uniqueEpisodeID}`                                                                  |
-| Pandora             | ❌            | `https://pandora.com/podcast/${slug}/${slug}/PC:${uniqueEpisodeID}`                                        |
-| Player FM           | ❌            | `https://player.fm/series/${uniquePlatformID}/${uniqueEpisodeID}`                                          |
-| Pocket Casts        | ❌            | `https://pca.st/episode/${uniqueEpisodeID}`                                                                |
-| Podbean             | ❌            | `https://podbean.com/media/share/dir-${uniqueEpisodeID}`                                                   |
-| Podcast Addict      | ✅            | `https://podcastaddict.com/episode/${encodeURIComponent(enclosureURL)}`                                    |
-| Podcast App         | ❌            | `https://podcast.app/${slug}-e${uniqueEpisodeID}`                                                          |
-| Podcast Guru        | ❌            | `https://app.podcastguru.io/podcast/${appleID}/episode/${slug}-${uniqueEpisodeID}`                         |
-| Podfriend           | ✅            | `https://podfriend.com/podcast/${appleID}/${encodeURIComponent(episodeGUID)}`                              |
-| Podknife            | ❌            | `https://podknife.com/episodes/${uniqueEpisodeID}`                                                         |
-| Podverse            | ❌            | `https://podverse.fm/episode/${uniqueEpisodeID}`                                                           |
-| Snipd               | ❌            | `https://share.snipd.com/episode/${uniquePlatformID}`                                                      |
-| Sonnet              | ❌            | `https://sonnet.fm/p/${appleID}/${uniqueEpisodeID}`                                                        |
-| Spotify             | ❌            | `https://open.spotify.com/episode/${uniqueEpisodeID}`                                                      |
-| Steno.fm            | ✅            | `https://steno.fm/show/${podcastGUID}/episode/${base64url(episodeGUID)}`                                   |
-| TrueFans            | ❌            | `https://truefans.fm/${slug}/${uniqueEpisodeID}`                                                           |
-| TuneIn              | ❌            | `https://tunein.com/podcasts/p${uniquePlatformID}/?topicId=${uniqueEpisodeID}`                             |
-| YouTube Music       | ❌            | `https://music.youtube.com/podcast/${uniqueEpisodeID}`                                                     |
+| Platform       | Foreign Keys | URL Pattern                                                                                                |
+|----------------|--------------|------------------------------------------------------------------------------------------------------------|
+| Amazon Music   | ❌            | `https://music.amazon.com/podcasts/${uniquePlatformID}/episodes/${uniqueEpisodeID}`                        |
+| Apple Podcasts | ❌            | `https://podcasts.apple.com/podcast/id${appleID}?i=${uniqueEpisodeID}`                                     |
+| Breez          | ✅            | `https://breez.link/p?feedURL=${encodeURIComponent(feedURL)}&episodeID=${encodeURIComponent(episodeGUID)}` |
+| Bullhorn       | ❌            | `https://bullhorn.fm/${uniquePlatformID}/posts/${uniqueEpisodeID}`                                         |
+| Castamatic     | ❌            | `https://castamatic.com/+${uniqueEpisodeID}`                                                               |
+| Castbox        | ❌            | `https://castbox.fm/episode/${slug}-id${uniquePlatformID}-id${uniqueEpisodeID}`                            |
+| Castro         | ❌            | `https://castro.fm/episode/${uniqueEpisodeID}`                                                             |
+| Deezer         | ❌            | `https://www.deezer.com/episode/${uniqueEpisodeID}`                                                        |
+| Fountain       | ✅            | `https://fountain.fm/episode/${podcastIndexEpisodeID}`                                                     |
+| Global Player  | ❌            | `https://www.globalplayer.com/podcasts/episodes/${uniqueEpisodeID}/`                                       |
+| Goodpods       | ❌            | `https://goodpods.com/podcasts/${uniquePlatformID}/${uniqueEpisodeID}`                                     |
+| Hark           | ❌            | `https://harkaudio.com/p/${uniquePlatformID}/${uniqueEpisodeID}`                                           |
+| iHeartRadio    | ❌            | `https://iheart.com/podcast/${slug}-${uniquePlatformID}/episode/${slug}-${uniqueEpisodeID}`                |
+| Jam            | ❌            | `https://www.listentojam.com/jam/${uniquePlatformID}/${uniqueEpisodeID}`                                   |
+| Luminary       | ❌            | `https://luminarypodcasts.com/listen/${slug}/${uniquePlatformID}/${slug}/${uniqueEpisodeID}`               |
+| Overcast       | ❌            | `https://overcast.fm/+${uniqueEpisodeID}`                                                                  |
+| Pandora        | ❌            | `https://pandora.com/podcast/${slug}/${slug}/PC:${uniqueEpisodeID}`                                        |
+| Player FM      | ❌            | `https://player.fm/series/${uniquePlatformID}/${uniqueEpisodeID}`                                          |
+| Pocket Casts   | ❌            | `https://pca.st/episode/${uniqueEpisodeID}`                                                                |
+| Podbean        | ❌            | `https://podbean.com/media/share/dir-${uniqueEpisodeID}`                                                   |
+| Podcast Addict | ✅            | `https://podcastaddict.com/episode/${encodeURIComponent(enclosureURL)}`                                    |
+| Podcast App    | ❌            | `https://podcast.app/${slug}-e${uniqueEpisodeID}`                                                          |
+| Podcast Guru   | ❌            | `https://app.podcastguru.io/podcast/${appleID}/episode/${slug}-${uniqueEpisodeID}`                         |
+| Podfriend      | ✅            | `https://podfriend.com/podcast/${appleID}/${encodeURIComponent(episodeGUID)}`                              |
+| Podknife       | ❌            | `https://podknife.com/episodes/${uniqueEpisodeID}`                                                         |
+| Podverse       | ❌            | `https://podverse.fm/episode/${uniqueEpisodeID}`                                                           |
+| Snipd          | ❌            | `https://share.snipd.com/episode/${uniquePlatformID}`                                                      |
+| Sonnet         | ❌            | `https://sonnet.fm/p/${appleID}/${uniqueEpisodeID}`                                                        |
+| Spotify        | ❌            | `https://open.spotify.com/episode/${uniqueEpisodeID}`                                                      |
+| Steno.fm       | ✅            | `https://steno.fm/show/${podcastGUID}/episode/${base64url(episodeGUID)}`                                   |
+| TrueFans       | ❌            | `https://truefans.fm/${slug}/${uniqueEpisodeID}`                                                           |
+| TuneIn         | ❌            | `https://tunein.com/podcasts/p${uniquePlatformID}/?topicId=${uniqueEpisodeID}`                             |
+| YouTube Music  | ❌            | `https://music.youtube.com/podcast/${uniqueEpisodeID}`                                                     |
 
 ## Resource Links
 These resources also support podcast foreign keys, but their primary purpose may be directing listeners to one of the apps above rather than a primary listening destination.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | Amazon Music        | ❌            | `https://music.amazon.com/podcasts/${uniquePlatformID}`                                                                                       |
 | AntennaPod          | ✅            | `https://antennapod.org/deeplink/subscribe?url=${feedURL}`                                                                                    |
 | Anytime Player      | ✅            | `https://anytimeplayer.app/subscribe?url=${feedURL}`                                                                                          |
-| Apollo              | ✅            | `https://shows.apollopods.com/show?feedUrl=${feedURL}`<br>For fiction podcasts only                                                           |
+| Apollo[^1]          | ✅            | `https://shows.apollopods.com/show?feedUrl=${feedURL}`                                                                                        |
 | Apple Podcasts      | ✅            | `https://podcasts.apple.com/podcast/id${appleID}`                                                                                             |
 | Breez               | ✅            | `https://breez.link/p?feedURL=${encodeURIComponent(feedURL)}`                                                                                 |
 | Castamatic          | ✅            | `https://castamatic.com/guid/${podcastGUID}`                                                                                                  |
@@ -146,5 +146,6 @@ These resources also support podcast foreign keys, but their primary purpose may
 If you have an update to improve this guide, please [fork the repo](https://github.com/nathangathright/podcast-platform-links/fork) and create a pull request. This Markdown document is easily editable from the GitHub web interface without the need to clone the repo locally.
 
 ## Footnotes
+[^1]: For fiction podcasts only
 [^1]: [Google Podcasts to shut down in 2024 with listeners migrated to YouTube Music](https://techcrunch.com/2023/09/26/google-podcasts-to-shut-down-in-2024-with-listeners-migrated-to-youtube-music/)
 [^2]: [RadioPublic is to close on March 31, 2024](https://podnews.net/uploads/radiopublic-closure.png)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | Amazon Music        | ❌            | `https://music.amazon.com/podcasts/${uniquePlatformID}`                                                                                       |
 | AntennaPod          | ✅            | `https://antennapod.org/deeplink/subscribe?url=${feedURL}`                                                                                    |
 | Anytime Player      | ✅            | `https://anytimeplayer.app/subscribe?url=${feedURL}`                                                                                          |
+| Apollo              | ✅            | `https://shows.apollopods.com/show?feedUrl=${feedURL}`<br>For fiction podcasts only                                                           |
 | Apple Podcasts      | ✅            | `https://podcasts.apple.com/podcast/id${appleID}`                                                                                             |
 | Breez               | ✅            | `https://breez.link/p?feedURL=${encodeURIComponent(feedURL)}`                                                                                 |
 | Castamatic          | ✅            | `https://castamatic.com/guid/${podcastGUID}`                                                                                                  |


### PR DESCRIPTION
Added Apollo. This app only lists fiction podcasts: the link will redirect to a "add this podcast" if not in the app's directory.