### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ These resources also support podcast foreign keys, but their primary purpose may
 
 | Platform        | URL Pattern                                                                                                                                           |
 |-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DeepCast        | `https://deepcast.fm/guid/${podcastGUID}` <br> `https://deepcast.fm/rss/${encodeURIComponent(feedURL)}` <br> `https://deepcast.fm/itunes/${appleID}`  |
 | Episodes.fm     | `https://episodes.fm/${appleID}` <br> `https://episodes.fm/${appleID}/episode/${base64url(episodeGUID)}`                                              |
 | Listen Notes    | `https://listennotes.com/itunes/id${appleID}`                                                                                                         |
 | Odesli          | `https://pods.link/i/${appleID}`                                                                                                                      |


### PR DESCRIPTION
Removal of DeepCast, after more than a month of being "temporarily unavailable".
https://podnews.net/uploads/deepcast-temporary-suspension.webp

