### PR TITLE
Add The Podcast App to Show Links and Episode Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | Sonnet           | ✅            | `https://sonnet.fm/p/${appleID}`                                            |
 | Spotify          | ❌            | `https://open.spotify.com/show/${uniquePlatformID}`                         |
 | Steno.fm         | ✅            | `https://steno.fm/show/${podcastGUID}`                                      |
+| The Podcast App  | ✅            | `https://thepodcastapp.dev/p/${podcastIndexShowID}`                         |
 | TrueFans         | ✅            | `https://truefans.fm/${podcastGUID}`                                        |
 | TuneIn           | ❌            | `https://tunein.com/podcasts/${uniquePlatformID}`                           |
 | YouTube Music    | ✅            | `https://music.youtube.com/library/podcasts?addrssfeed=${base64url(feedURL}`<br>`https://music.youtube.com/playlist?list=${uniquePlatformID}`|
@@ -111,6 +112,7 @@ The distributed nature of podcasting makes it complicated to link to a show/epis
 | Sonnet         | ❌            | `https://sonnet.fm/p/${appleID}/${uniqueEpisodeID}`                                                        |
 | Spotify        | ❌            | `https://open.spotify.com/episode/${uniqueEpisodeID}`                                                      |
 | Steno.fm       | ✅            | `https://steno.fm/show/${podcastGUID}/episode/${base64url(episodeGUID)}`                                   |
+| The Podcast App | ❌           | `https://thepodcastapp.dev/e/${uniqueEpisodeID}`                                                           |
 | TrueFans       | ❌            | `https://truefans.fm/${slug}/${uniqueEpisodeID}`                                                           |
 | TuneIn         | ❌            | `https://tunein.com/podcasts/p${uniquePlatformID}/?topicId=${uniqueEpisodeID}`                             |
 | YouTube Music  | ❌            | `https://music.youtube.com/podcast/${uniqueEpisodeID}`                                                     |

--- a/schemes.md
+++ b/schemes.md
@@ -66,6 +66,7 @@ Since iOS 9.2, Apple has encouraged developers to adopt [universal links](https:
 | Soundcloud      | `soundcloud://`                                                              |
 | Spotify         | `spotify://`                                                                 |
 | Spreaker        | `spreaker://`                                                                |
+| The Podcast App | `thepodcastapp://`                                                           |
 | TuneIn          | `tunein://`                                                                  |
 | Wondery         | `wondery://`                                                                 |
 | YouTube         | `youtube://${deepLink}`                                                      |


### PR DESCRIPTION
This adds **The Podcast App** (by Magnolia Apps — https://thepodcastapp.dev, iOS + Android) to the Show Links and Episode Links tables, plus its custom URL scheme in schemes.md.

**Show links** are stateless and can be constructed from the Podcast Index show ID alone:

`https://thepodcastapp.dev/p/${podcastIndexShowID}`

Working example: https://thepodcastapp.dev/p/920666 (Podcasting 2.0)

These are universal links / Android App Links (apple-app-site-association and assetlinks.json are live at https://thepodcastapp.dev/.well-known/), so they open the show directly in the app when installed and render a web landing page for the show when not.

**Episode links** use a platform-specific short ID generated when an episode is shared from the app, so the episode row is marked ❌:

`https://thepodcastapp.dev/e/${uniqueEpisodeID}`

Note: this is a different app from the existing "Podcast App" (podcast.app) entry — The Podcast App is `com.magnolia.thepodcastapp`.

App Store: https://apps.apple.com/app/the-podcast-app/id6754806244
Google Play: https://play.google.com/store/apps/details?id=com.magnolia.thepodcastapp